### PR TITLE
Fix timeout handler

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -285,6 +285,9 @@ export class FluentClient {
     if (this.flushing) {
       return this.sendQueue.queueLength > 0;
     }
+    if (!this.socket.writable()) {
+      return this.sendQueue.queueLength > 0;
+    }
     this.flushing = true;
     if (this.nextFlushTimeoutId !== null) {
       clearTimeout(this.nextFlushTimeoutId);
@@ -350,7 +353,7 @@ export class FluentClient {
   }
 
   private sendNext(): boolean {
-    let chunk: string | undefined;
+    let chunk: protocol.Chunk | undefined;
     if (this.ackEnabled) {
       chunk = crypto.randomBytes(16).toString("base64");
     }

--- a/src/error.ts
+++ b/src/error.ts
@@ -78,3 +78,9 @@ export class DecodeError extends BaseError {
     super(message);
   }
 }
+
+export class FatalSocketError extends BaseError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -64,7 +64,7 @@ const isConnected = (state: SocketState): boolean => {
 
 /**
  * A wrapper around a Fluent Socket
- * 
+ *
  * Handles connecting the socket, and manages error events and reconnection
  */
 export class FluentSocket extends EventEmitter {
@@ -477,7 +477,7 @@ export class FluentSocket extends EventEmitter {
    * Write data to the socket
    *
    * Fails if the socket is not writable
-   * 
+   *
    * @param data The data to write to the socket
    * @returns A Promise, which resolves when the data is successfully written to the socket, or rejects if it couldn't be written
    */

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,8 +9,17 @@ export const fakeSocket = (): {
 } => {
   const readable = new PassThrough();
   const writable = new PassThrough();
+  const socket = duplexer3({allowHalfOpen: false}, readable, writable);
+  socket.on("end", () => {
+    socket.destroy();
+    socket.emit("close");
+  });
+  socket.on("finish", () => {
+    socket.destroy();
+    socket.emit("close");
+  });
   return {
-    socket: duplexer3(readable, writable),
+    socket,
     readable,
     writable,
   };

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -3,7 +3,7 @@ import * as chaiAsPromised from "chai-as-promised";
 import * as sinon from "sinon";
 
 import {FluentAuthSocket, FluentAuthOptions} from "../src/auth";
-import {FluentSocketOptions} from "../src/socket";
+import {CloseState, FluentSocketOptions} from "../src/socket";
 import * as protocol from "../src/protocol";
 import {fakeSocket} from "./helpers";
 
@@ -346,7 +346,7 @@ describe("FluentAuthSocket", () => {
       const oldStream = stream;
       stream = fakeSocket();
       stream.readable.on("data", dataHandler);
-      socket.closeAndReconnect();
+      socket.close(CloseState.RECONNECT);
       // new stream
       socket.once("writable", () => {
         expect(oldStream.socket.destroyed).to.be.true;


### PR DESCRIPTION
Timeouts should put the socket into an IDLE state, which reconnects later, and not emit an error. This prevents endless errors. Also fix needing to specify an error handler, or otherwise run into a node crash.