### PR TITLE
Add a separate limit for when the socket is not writable

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/jamiees2/fluentd-node"
   },
   "bugs": "https://github.com/jamiees2/fluentd-node/issues",
-  "homepage": "https://github.com/jamiees2/fluentd-node",
+  "homepage": "https://jamiees2.github.io/fluentd-node/",
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
Limit for when the socket isn't writable. This allows for bursty type workloads where the limit isn't enforced unless the socket is disconnected, maximizing throughput.

Also clean up the limit API to share more code, and fix the package.json URL.