### PR TITLE
Fix flush bug

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -541,6 +541,7 @@ export class FluentClient {
       } else if (this.nextFlushTimeoutId === null) {
         // Otherwise, schedule the next flush interval
         this.nextFlushTimeoutId = setTimeout(() => {
+          this.nextFlushTimeoutId = null;
           this.flush();
         }, this.flushInterval);
       }
@@ -556,12 +557,18 @@ export class FluentClient {
    * @param limit The limit to enforce
    */
   private dropLimit(limit: SendQueueLimit): void {
-    if (this.sendQueue.queueSize > limit.size) {
+    if (
+      this.sendQueue.queueSize !== -1 &&
+      this.sendQueue.queueSize > limit.size
+    ) {
       while (this.sendQueue.queueSize > limit.size) {
         this.sendQueue.dropEntry();
       }
     }
-    if (this.sendQueue.queueLength > limit.length) {
+    if (
+      this.sendQueue.queueLength !== -1 &&
+      this.sendQueue.queueLength > limit.length
+    ) {
       while (this.sendQueue.queueLength > limit.length) {
         this.sendQueue.dropEntry();
       }

--- a/src/modes/queue.ts
+++ b/src/modes/queue.ts
@@ -34,10 +34,14 @@ export type PacketData = {
 export abstract class Queue {
   /**
    * The # of entries in the queue
+   *
+   * -1 if the queue implementation doesn't expose this
    */
   public abstract get queueLength(): number;
   /**
    * The total size of the queue
+   *
+   * -1 if the queue implementation doesn't expose this
    */
   public abstract get queueSize(): number;
   /**


### PR DESCRIPTION
A sequence of events could cause the queue to never flush under the interval because the timeout id wasn't nulled. This should fix that.