### PR TITLE
Fix event retrier not cleaning up during shutdown

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -71,7 +71,7 @@ export class SocketNotWritableError extends BaseError {
 }
 
 /**
- * Thrown when an event is dropped for any reason
+ * Thrown when an event is dropped from the queue for any reason
  */
 export class DroppedError extends BaseError {
   constructor(message: string) {
@@ -80,9 +80,29 @@ export class DroppedError extends BaseError {
 }
 
 /**
- * Thrown when an event is dropped as a result of clearing out the queue
+ * Thrown when an event is dropped as a result of clearing out the queue on shutdown
+ *
+ * Extends DroppedError since the message was dropped from the queue
  */
-export class ClearDroppedError extends DroppedError {
+export class QueueShutdownError extends DroppedError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown into the ack queue on shutdown, terminating all promises waiting for an ack
+ */
+export class AckShutdownError extends BaseError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when the EventRetrier is shut down
+ */
+export class RetryShutdownError extends BaseError {
   constructor(message: string) {
     super(message);
   }
@@ -98,16 +118,9 @@ export class AuthError extends BaseError {
 }
 
 /**
- * Thrown into the ack queue on shutdown, terminating all promises waiting for an ack
- */
-export class ShutdownError extends BaseError {
-  constructor(message: string) {
-    super(message);
-  }
-}
-
-/**
  * Thrown when the shared key doesn't match
+ *
+ * Extends AuthError, since the key was incorrect
  */
 export class SharedKeyMismatchError extends AuthError {
   constructor(message: string) {

--- a/src/modes/queue.ts
+++ b/src/modes/queue.ts
@@ -1,6 +1,6 @@
 import * as protocol from "../protocol";
 import {DeferredPromise} from "p-defer";
-import {ClearDroppedError, DroppedError} from "../error";
+import {DroppedError, QueueShutdownError} from "../error";
 
 /**
  * Every queue must have this type of data
@@ -96,7 +96,7 @@ export abstract class Queue {
     let entryData: EntryData | null;
     while ((entryData = this.pop()) !== null) {
       entryData.deferred.reject(
-        new ClearDroppedError("Message dropped due to queue shutdown")
+        new QueueShutdownError("Message dropped due to queue shutdown")
       );
     }
   }

--- a/test/test.event_retrier.ts
+++ b/test/test.event_retrier.ts
@@ -1,0 +1,94 @@
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as sinon from "sinon";
+import * as pDefer from "p-defer";
+import {EventRetrier} from "../src/event_retrier";
+import {RetryShutdownError} from "../src/error";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+const sandbox = sinon.createSandbox();
+
+describe("EventRetrier", () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+  it("should retry events", async () => {
+    const makePromise = sandbox.stub();
+    makePromise.onFirstCall().rejects();
+    makePromise.onSecondCall().resolves();
+
+    const retrier = new EventRetrier();
+
+    await retrier.retryPromise(makePromise);
+
+    sinon.assert.calledTwice(makePromise);
+  });
+
+  it("should successfully short circuit", async () => {
+    const clock = sandbox.useFakeTimers();
+    const clearTimeoutSpy = sandbox.spy(clock, "clearTimeout");
+
+    const firstCall = pDefer<void>();
+    const makePromise = sandbox.stub();
+    makePromise.onFirstCall().callsFake(() => {
+      firstCall.resolve();
+      return Promise.reject();
+    });
+    makePromise.onSecondCall().resolves();
+
+    // long delay
+    const retrier = new EventRetrier({minDelay: 50000000});
+
+    const retryPromise = retrier.retryPromise(makePromise);
+
+    sinon.assert.calledOnce(makePromise);
+
+    await expect(firstCall.promise).to.eventually.be.fulfilled;
+
+    expect(retryPromise).to.not.be.fulfilled;
+
+    await retrier.shortCircuit();
+
+    sinon.assert.calledTwice(makePromise);
+
+    expect(retryPromise).to.be.fulfilled;
+
+    // Make sure we cleared out the timeout after short circuit
+    sinon.assert.calledOnce(clearTimeoutSpy);
+  });
+
+  it("should successfully shut down", async () => {
+    const clock = sandbox.useFakeTimers();
+    const clearTimeoutSpy = sandbox.spy(clock, "clearTimeout");
+
+    const firstCall = pDefer<void>();
+    const makePromise = sandbox.stub();
+    makePromise.onFirstCall().callsFake(() => {
+      firstCall.resolve();
+      return Promise.reject();
+    });
+    makePromise.onSecondCall().resolves();
+
+    // long delay
+    const retrier = new EventRetrier({minDelay: 50000000});
+
+    const retryPromise = retrier.retryPromise(makePromise);
+
+    sinon.assert.calledOnce(makePromise);
+
+    await expect(firstCall.promise).to.eventually.be.fulfilled;
+
+    expect(retryPromise).to.not.be.fulfilled;
+
+    await retrier.shutdown();
+
+    sinon.assert.calledOnce(makePromise);
+
+    expect(retryPromise).to.be.rejectedWith(RetryShutdownError);
+
+    // Make sure we cleared out the timeout after shutdown
+    sinon.assert.calledOnce(clearTimeoutSpy);
+  });
+});


### PR DESCRIPTION
The retrier doesn't clean up pending events during shutdown, which causes the event loop to wait for pending events, and stall during shutdowns. 

Also clean up timeouts in tests, and add tests to make sure we shutdown cleanly.