### PR TITLE
Fix error handling

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
     "enable-source-maps": true,
-    "timeout": 160000,
+    "timeout": 10000,
     "throw-deprecation": true
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -111,7 +111,7 @@ export class FluentAuthSocket extends FluentSocket {
       super.onMessage(message);
     } else {
       this.close(
-        CloseState.CLOSE,
+        CloseState.FATAL,
         new UnexpectedMessageError("Received unexpected message")
       );
     }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -12,11 +12,9 @@ export const fakeSocket = (): {
   const socket = duplexer3({allowHalfOpen: false}, readable, writable);
   socket.on("end", () => {
     socket.destroy();
-    socket.emit("close");
   });
   socket.on("finish", () => {
     socket.destroy();
-    socket.emit("close");
   });
   return {
     socket,

--- a/test/test.socket.ts
+++ b/test/test.socket.ts
@@ -191,15 +191,11 @@ describe("FluentSocket", () => {
 
     const spy = sinon.spy(socket, "connect");
 
-    socket.on("close", () => {
-      process.nextTick(() => {
-        expect((<any>socket).reconnectTimeoutId).to.be.null;
-        sinon.assert.notCalled(spy);
-        done();
-      });
-    });
-    socket.on("writable", () => {
-      socket.close(CloseState.CLOSE);
+    socket.on("writable", async () => {
+      await socket.disconnect();
+      expect((<any>socket).reconnectTimeoutId).to.be.null;
+      sinon.assert.notCalled(spy);
+      done();
     });
   });
 


### PR DESCRIPTION
This fixes a number of bugs:

Closing the socket from the event stream could close the socket without reconnects. I ended up just removing the close closestate, and moving bad messages to fatal errors.

The connect function could enter an indefinite recursive loop when the connection was taking too long to connect, fixed by using Promises for connect functions

Add a sendQueueNotFlushableLimitDelay to delay the flushing during non writable events. This prevents the client from dropping events during short downtimes.

Also shortens the test timeout, the longest test takes less than 200ms.