### PR TITLE
fix reconnect disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ const logger = new FluentClient("tag_prefix", {
     disableReconnect: true
   }
 });
+// If you disable reconnections, the socket has to be manually connected, 
+// connect() returns a promise, which rejects on connection errors.
+logger.connect();
 ```
 
 ### Shared key authentication

--- a/src/client.ts
+++ b/src/client.ts
@@ -253,7 +253,11 @@ export class FluentClient {
       this.socket.on("error", options.onSocketError);
     }
 
-    this.connect();
+    // Only connect if we're able to reconnect
+    // Otherwise we expect an explicit connect() which will handle connection errors
+    if (!options.socket?.disableReconnect) {
+      this.connect();
+    }
   }
 
   /**

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -80,7 +80,9 @@ export type FluentSocketOptions = {
    */
   reconnect?: Partial<ReconnectOptions>;
   /**
-   * Disable reconnection on failure. This can be useful for one-offs
+   * Disable reconnection on failure. This can be useful for one-offs, or if you'd like to manually manage the connection.
+   *
+   * Prevents the socket from being created on client create.
    *
    * Defaults to false
    */

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -18,6 +18,8 @@ describe("FluentServer", () => {
       socket: {port: server.port || undefined, disableReconnect: true},
     });
 
+    await client.connect();
+
     const eventPromise = new Promise<{
       tag: protocol.Tag;
       time: protocol.Time;
@@ -48,6 +50,8 @@ describe("FluentServer", () => {
       socket: {port: server.port || undefined, disableReconnect: true},
       ack: {},
     });
+
+    await client.connect();
 
     const eventPromise = new Promise<{
       tag: protocol.Tag;
@@ -87,6 +91,8 @@ describe("FluentServer", () => {
       socket: {port: server.port || undefined, disableReconnect: true},
       security: {clientHostname: "test-client", sharedKey: "foo"},
     });
+
+    await client.connect();
 
     const eventPromise = new Promise<{
       tag: protocol.Tag;
@@ -131,6 +137,8 @@ describe("FluentServer", () => {
         password: "hunter2",
       },
     });
+
+    await client.connect();
 
     const eventPromise = new Promise<{
       tag: protocol.Tag;


### PR DESCRIPTION
If reconnections are disabled, the FluentClient constructor can throw an unhandledPromiseRejection, which isn't ideal. 

Thinking about it, we're not doing a great job of supporting reconnectDisabled, since we should also expose the events on the socket so that the user can decide to reconnect. For now this isn't used, so we can probably come back to it, just like the server :)