### PR TITLE
add queue length

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -801,4 +801,22 @@ export class FluentClient {
     // i.e we have emptied PromiseJobs
     return new Promise(r => process.nextTick(r));
   }
+
+  /**
+   * Returns the number of queued events that haven't been sent yet
+   *
+   * Useful to react if we're queuing up too many events within a single tick
+   */
+  get queueLength(): number {
+    return this.sendQueue.queueLength;
+  }
+
+  /**
+   * Returns whether or not the socket is writable
+   *
+   * Useful to react if we're disconnected for any reason
+   */
+  get writable(): boolean {
+    return this.socket.writable();
+  }
 }


### PR DESCRIPTION
This adds getters for queueLength and writable, allowing clients to make external decisions on when to call `flush()` for example.