### PR TITLE
Add last method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -856,4 +856,15 @@ export class FluentClient {
   get writable(): boolean {
     return this.socket.writable();
   }
+
+  /**
+   * Returns the last element in the queue. 
+   * When this promise resolves, we're guaranteed that the queue 
+   * has flushed up to this point
+   * 
+   * @returns A Promise which resolves once the queue has flushed, or null if the queue is empty
+   */
+  public last(): Promise<void> | null {
+    return this.sendQueue.last();
+  }
 }

--- a/src/modes/forward.ts
+++ b/src/modes/forward.ts
@@ -58,6 +58,11 @@ export class ForwardQueue extends Queue {
     }
   }
 
+  public last(): Promise<void> | null {
+    const lastEntry = Array.from(this.sendQueue.values()).pop();
+    return lastEntry ? lastEntry.deferred.promise : null;
+  }
+
   public pop(): ForwardRecord | null {
     if (this.sendQueue.size === 0) {
       return null;

--- a/src/modes/message.ts
+++ b/src/modes/message.ts
@@ -49,6 +49,11 @@ export class MessageQueue extends Queue {
     return deferred.promise;
   }
 
+  public last(): Promise<void> | null {
+    const lastEntry = Array.from(this.sendQueue.values()).pop();
+    return lastEntry ? lastEntry.deferred.promise : null;
+  }
+
   protected pop(): EventRecord | null {
     if (this.sendQueue.size === 0) {
       return null;

--- a/src/modes/packed_forward.ts
+++ b/src/modes/packed_forward.ts
@@ -76,6 +76,11 @@ class BasePackedForwardQueue extends Queue {
     }
   }
 
+  public last(): Promise<void> | null {
+    const lastEntry = Array.from(this.sendQueue.values()).pop();
+    return lastEntry ? lastEntry.deferred.promise : null;
+  }
+
   protected pop(): PackedRecord | null {
     if (this.sendQueue.size === 0) {
       return null;

--- a/src/modes/queue.ts
+++ b/src/modes/queue.ts
@@ -58,6 +58,13 @@ export abstract class Queue {
     data: protocol.EventRecord
   ): Promise<void>;
   /**
+   * Returns the Promise for the last element in the queue. Note that this may not be the last push() call
+   * especially in the case of *Forward modes
+   * 
+   * @returns The same promise from the push() which is queued last (if we were to call nextPacket in a loop, this promise would be the last one)
+   */
+  public abstract last(): Promise<void> | null;
+  /**
    * Returns the next packet to send from the queue
    *
    * @param chunk A Chunk ID to send along, for acknowledgements if enabled


### PR DESCRIPTION
This adds a getter which enables you to access the last method of each promise. This allows implementations to block until the last event has been successfully flushed or acknowledged.