### PR TITLE
Add notWritableWhenDraining, and expose events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {FluentClient} from "./client";
 export {FluentServer} from "./server";
 export {default as EventTime} from "./event_time";
+export {FluentSocketEvent} from "./socket";
 
 export type {FluentSocketOptions, ReconnectOptions} from "./socket";
 export type {FluentAuthOptions} from "./auth";

--- a/test/test.client.ts
+++ b/test/test.client.ts
@@ -15,6 +15,7 @@ import {
   AckShutdownError,
 } from "../src/error";
 import {awaitNextTick, awaitTimeout} from "../src/util";
+import {FluentSocketEvent} from "../src/socket";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -465,12 +466,11 @@ describe("FluentClient", () => {
     });
   });
 
-  it("should forward errors", done => {
-    const {socket} = createFluentClient("test", {
-      onSocketError: (err: Error) => {
-        expect(err.message).to.equal("test");
-        done();
-      },
+  it("should forward error events", done => {
+    const {socket, client} = createFluentClient("test");
+    client.socketOn(FluentSocketEvent.ERROR, (err: Error) => {
+      expect(err.message).to.equal("test");
+      done();
     });
     socket.emit("error", new Error("test"));
   });


### PR DESCRIPTION
blocking writes until drains isn't really useful unless you're using event limits, or have a way to pause event emission. Instead, it becomes a bottleneck, requiring more event loop ticks to emit the same mount of data to the socket. Filling up the send buffer instead causes nodejs to flush the buffer in the background, which can be a lot better.

Also exposes the socket events for more monitoring goodness.