### PR TITLE
Fix EventEmitter leak

### DIFF
--- a/test/test.socket.ts
+++ b/test/test.socket.ts
@@ -60,6 +60,19 @@ describe("FluentSocket", () => {
     sinon.assert.calledOnce(connectStub);
   });
 
+  it("should not preserve error handlers after connect", done => {
+    const {socket, connectStub} = createFluentSocket({disableReconnect: true});
+
+    socket.on(FluentSocketEvent.WRITABLE, () => {
+      expect(socket.listenerCount(FluentSocketEvent.ERROR)).to.equal(0);
+      done();
+    });
+
+    socket.connect();
+
+    sinon.assert.calledOnce(connectStub);
+  });
+
   it("should not block for draining on write by default", done => {
     const {socket, stream, connectStub} = createFluentSocket({
       disableReconnect: true,


### PR DESCRIPTION
We were leaking event handlers by always attaching to the FluentSocket eventEmitter. When there is no error event but lots of timeouts, we end up attaching lots of error listeners and never removing them.

Fixes #20 I think

