### PR TITLE
fix(socket): TLS connection correctly times out

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -400,7 +400,11 @@ export class FluentSocket extends EventEmitter {
    * @returns A new socket to use for the connection
    */
   private createTlsSocket(): tls.TLSSocket {
-    return tls.connect({...this.tlsOptions, ...this.socketParams});
+    let opts: net.NetConnectOpts = {...this.tlsOptions, ...this.socketParams};
+    if (this.timeout >= 0) {
+      opts = {...opts, timeout: this.timeout};
+    }
+    return tls.connect(opts);
   }
 
   /**


### PR DESCRIPTION
Hey @jamiees2 - we found a funny one with the `timeout` setting. Turns out we were only passing the `timeout` setting to non-TLS connections. Would appreciate it if you could take a look at this one. Thanks!