### PR TITLE
fix: default `maxDelay` to max 32-bit signed integer

### DIFF
--- a/src/event_retrier.ts
+++ b/src/event_retrier.ts
@@ -1,5 +1,10 @@
 import {DroppedError, RetryShutdownError} from "./error";
-import {awaitAtMost, pDefer, DeferredPromise} from "./util";
+import {
+  awaitAtMost,
+  pDefer,
+  DeferredPromise,
+  Max32BitSignedInteger,
+} from "./util";
 
 /**
  * Event retry settings
@@ -54,7 +59,7 @@ export class EventRetrier {
       backoff: 2,
       delay: 100,
       minDelay: -Infinity,
-      maxDelay: +Infinity,
+      maxDelay: Max32BitSignedInteger,
       onError: () => {},
       ...(opts || {}),
     };

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -10,6 +10,7 @@ import {
 } from "./error";
 import * as protocol from "./protocol";
 import {PassThrough, Duplex} from "stream";
+import {Max32BitSignedInteger} from "./util";
 
 /**
  * Reconnection settings for the socket
@@ -320,7 +321,7 @@ export class FluentSocket extends EventEmitter {
       backoff: 2,
       delay: 500, // default is 500ms
       minDelay: -Infinity,
-      maxDelay: +Infinity,
+      maxDelay: Max32BitSignedInteger,
       ...(options.reconnect || {}),
     };
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,3 +43,5 @@ export const pDefer = <T>(): DeferredPromise<T> => {
   });
   return deferred as DeferredPromise<T>;
 };
+
+export const Max32BitSignedInteger = 2 ** 31 - 1;


### PR DESCRIPTION
This PR updates the default `maxDelay` to the maximum 32-bit signed integer (`2 ** 31 - 1`).

The default `maxDelay` of `Infinity` doesn't make sense, since `setTimeout` doesn't accept anything larger than the maximum 32-bit signed integer; when that value is exceeded, `setTimeout` treats it as `1`, which can cause runaway retries.

Resolves https://github.com/fluent/fluent-logger-forward-node/issues/44.